### PR TITLE
feat: overhaul ensemble pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ CNN (PyTorch, GPU)
   Conv2D × 3 blocks → GlobalAvgPool → sigmoid → reversal probability [0,1]
     │
     ▼
+Quality Gate (pipeline/inference.py)
+  Check 1 — rare letter dominance:
+    rare_ratio = count(z,x,q,j,w,v) / n
+    if rare_ratio > 0.55 → Inconclusive
+    (noise/background regions produce these letters; real text never dominates with them)
+  Check 2 — raw CNN reversal ceiling:
+    if mean(cnn_probs) > 0.65 → Inconclusive
+    (worst-case genuine dyslexic text stays below 0.65; noise regions exceed it)
+    │
+    ▼
 NLP component (hybrid)
   Analytical score:
     strong_count (CNN ≥ 0.85) / max(n × 0.08, 5)
@@ -239,6 +249,29 @@ No single modality is sufficient. A writer who reverses letters cleanly (high ML
 
 Deliberately excluded. A horizontally flipped 'b' is a 'd' — which is exactly the reversal pattern being detected. Including it as augmentation would teach the model that both orientations are equivalent, destroying its ability to detect reversals. This is a domain-specific augmentation choice motivated by the nature of the classification task.
 
+### Why a quality gate before the ensemble?
+
+When character extraction fails — due to a noisy image, extreme angle, faint ink,
+or cluttered background — the downstream models process garbage and produce
+confidently wrong outputs. The ensemble has no way to know the input was invalid.
+
+Two independent checks catch this before any scoring happens:
+
+**Rare letter dominance:** Background noise and stroke fragments get misclassified
+as z, x, q, j, w, v — letters with distinctive shapes that match common noise
+patterns. These letters make up under 3% of normal English text. If they exceed
+55% of predictions, the extractor grabbed non-character regions. This check is
+deliberately inverted from checking for common letter presence — short real words
+like "KITE FAMILY" legitimately contain few common letters (e, t, a, o, i, n...)
+but will never be dominated by rare ones.
+
+**Raw reversal ceiling:** Even worst-case dyslexic short text — 4 of 10 characters
+genuinely reversed plus moderate CNN responses on visually ambiguous letters —
+stays below 0.65 raw mean. Noise regions consistently exceed this. The threshold
+provides headroom for genuine edge cases while blocking haywire extractions.
+
+Both thresholds are set conservatively to avoid false Inconclusive results on
+legitimate images, and both are configurable in `QualityGateConfig` in `config.py`.
 ---
 
 ## Key Improvements Over Beta Versions
@@ -267,6 +300,7 @@ Deliberately excluded. A horizontally flipped 'b' is a 'd' — which is exactly 
 | Flask sessions | Shared filename (race condition on concurrent requests) | UUID-keyed per-request sessions |
 | File cleanup | `shutil.rmtree` in finally block | Daemon thread auto-delete after 5 min |
 | Input validation | None | Extension check + magic-byte MIME validation + size limit |
+| Quality gate | None — failed extraction scored as high dyslexia probability | Rare letter dominance + raw reversal ceiling block bad extractions before ensemble |
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -133,6 +133,35 @@ class EnsembleConfig:
     EXPECTED_REVERSAL_RATE  = 0.08
     MIN_REVERSAL_EXPECTED   = 5      # floor prevents short-text over-sensitivity
 
+class QualityGateConfig:
+    # Letters that are extremely rare in real English text AND
+    # that background noise, paper texture, and stroke fragments
+    # commonly get misclassified as (due to their distinctive shapes).
+    # Checking for DOMINANCE of rare letters is more robust than checking
+    # for ABSENCE of common ones — especially for short texts where
+    # words like "KITE FAMILY" legitimately contain few common letters.
+    RARE_LETTERS          = set('zxqjwv')
+
+    # If more than 55% of predicted letters are from the rare set,
+    # the extractor almost certainly grabbed noise rather than characters.
+    # Real text — even heavily misspelled dyslexic short words —
+    # will not produce this distribution.
+    # Example haywire sequence (250 chars): Z~12% W~15% Y~10% Q~4% = ~45%+
+    # Example KITE FAMILY: only Y is rare = 10%. Far below threshold.
+    MAX_RARE_LETTER_RATIO = 0.55
+
+    # Raw CNN reversal mean upper bound.
+    # Set to 0.65 to handle worst-case short dyslexic text:
+    # 4 of 10 characters genuinely inverted (40%) + moderate CNN
+    # responses on visually ambiguous letters (A, I, M) = up to ~55%.
+    # 0.65 provides headroom while still catching haywire extractions
+    # (which score ~70-80% raw reversal on noise regions).
+    MAX_RAW_REVERSAL_RATE = 0.65
+
+    # Minimum characters for any meaningful analysis
+    MIN_CHARACTERS        = 4
+    
+    
 # ---------------------------------------------------------------------------
 # Synthetic NLP data generation
 # ---------------------------------------------------------------------------

--- a/pipeline/inference.py
+++ b/pipeline/inference.py
@@ -72,6 +72,66 @@ def _encode_seq_numpy(seq: str) -> np.ndarray:
 # ---------------------------------------------------------------------------
 # Core inference
 # ---------------------------------------------------------------------------
+def _assess_extraction_quality(
+    mlp_preds:  np.ndarray,
+    cnn_probs:  list[float],
+) -> tuple[bool, str]:
+    """
+    Sanity-check character extraction before running the ensemble.
+
+    Two checks:
+
+    1. Rare letter dominance
+       Letters z, x, q, j, w, v are extremely uncommon in real English text
+       and are frequently produced by misclassifying background noise, paper
+       texture, and stroke fragments. If they dominate the predictions the
+       extractor grabbed non-character regions.
+
+       Inverted logic vs. checking for common letter presence:
+       Short real words like "KITE FAMILY" legitimately contain few
+       common letters (e, t, a, o, i, n, s, h, r, d, l, u) but will
+       never be dominated by z, x, q, j, w, v.
+
+    2. Raw CNN reversal rate
+       Even worst-case dyslexic short text (40% of characters genuinely
+       reversed + moderate CNN responses on ambiguous letters) stays below
+       0.65. Above this the CNN is processing noise regions, not characters.
+
+    Returns (passed: bool, reason: str)
+    """
+    from config import QualityGateConfig as QCfg
+
+    n = len(mlp_preds)
+    if n < QCfg.MIN_CHARACTERS:
+        return False, (
+            f"Too few characters detected ({n}). "
+            f"Please upload an image with more clearly written text."
+        )
+
+    # Check 1 — rare letter dominance
+    letters    = [chr(int(p) + 97) for p in mlp_preds]
+    rare_ratio = sum(1 for l in letters if l in QCfg.RARE_LETTERS) / n
+    if rare_ratio > QCfg.MAX_RARE_LETTER_RATIO:
+        return False, (
+            f"Poor extraction quality: {rare_ratio:.1%} of predicted characters "
+            f"are rare English letters (z, x, q, j, w, v), which typically "
+            f"indicates the character extractor segmented image noise or background "
+            f"texture rather than actual handwriting. Try a clearer, higher-contrast "
+            f"image with the text filling most of the frame."
+        )
+
+    # Check 2 — raw reversal rate ceiling
+    raw_reversal = float(np.mean(cnn_probs))
+    if raw_reversal > QCfg.MAX_RAW_REVERSAL_RATE:
+        return False, (
+            f"Poor extraction quality: raw reversal rate of {raw_reversal:.1%} "
+            f"exceeds the plausible maximum ({QCfg.MAX_RAW_REVERSAL_RATE:.0%}). "
+            f"The character extractor likely segmented image noise or background "
+            f"regions rather than actual handwritten characters."
+        )
+
+    return True, ""
+
 
 def run_inference(image_path: str) -> "DiagnosisResult":
     from pipeline.character_extraction import extract_characters
@@ -117,8 +177,26 @@ def run_inference(image_path: str) -> "DiagnosisResult":
     cnn_imgs = np.stack([c.cnn_input for c in characters])    # (N, 64, 64, 1)
     cnn_probs = predict_batch(cnn, cnn_imgs).tolist()          # (N,)
     
+    predicted_seq    = "".join(chr(int(p) + 97) for p in mlp_preds)
+
+    # ── 4. Quality gate — catch failed extraction before ensemble ─────────────
+    quality_ok, quality_reason = _assess_extraction_quality(mlp_preds, cnn_probs)
+    if not quality_ok:
+        logger.warning("Quality gate failed: %s", quality_reason)
+        return DiagnosisResult(
+            result           = "Inconclusive",
+            ensemble_score   = 0.0,
+            confidence_label = "Low",
+            reversal_rate    = 0.0,
+            nlp_anomaly_score= 0.0,
+            mlp_uncertainty  = 0.0,
+            num_characters   = len(characters),
+            predicted_sequence = predicted_seq.upper() if 'predicted_seq' in dir() else "",
+            per_character    = [],
+            message          = quality_reason,
+        )
     
-    # ── 4. NLP: analytical score blended with LSTM ───────────────────────────
+    # ── 5. NLP: analytical score blended with LSTM ───────────────────────────
     #
     # Analytical score: derived from CNN reversal probabilities directly.
     # Counts strong reversals (CNN ≥ 0.85) normalised against clinical
@@ -137,7 +215,6 @@ def run_inference(image_path: str) -> "DiagnosisResult":
 
     from models.ensemble import compute_analytical_nlp
 
-    predicted_seq    = "".join(chr(int(p) + 97) for p in mlp_preds)
     analytical_score = compute_analytical_nlp(cnn_probs)
 
     try:


### PR DESCRIPTION
## Ensemble Pipeline Overhaul

### Problem
The ensemble was producing incorrect results across two distinct failure modes:

1. **Long paragraph dilution** — a writer with 20 reversals in 200 characters
   scored a global mean of 10%, burying a clinically significant finding.

2. **Failed extraction → false positive** — when character extraction grabbed
   background noise or image clutter instead of actual characters, all three
   downstream models processed garbage and produced confidently wrong outputs.
   A normal handwriting image with a noisy background was scoring 76.5% dyslexia
   probability.

### Changes

**`config.py`**
- `EnsembleConfig`: updated weights (CNN 0.55 / NLP 0.40 / MLP 0.05),
  removed `NLP_CAP`
- `QualityGateConfig`: new class — rare letter threshold (0.55),
  raw reversal ceiling (0.65), min characters (4)

**`models/ensemble.py`**
- Replaced global reversal mean with strong-binary sliding window.
  Only characters where CNN ≥ 0.85 are counted — filters cursive stroke
  false positives (50–80%) while preserving genuine reversals (90–100%).
  Window blends global rate with local peak; blend weight shifts toward
  local as text length grows.
- Added `compute_analytical_nlp()` — counts strong reversals normalised
  against clinical expectation of 8% for a diagnosed dyslexic writer.
  Does not saturate from image noise.
- `compute_ensemble()` now returns `(score, cnn_component, nlp_component,
  result, confidence_label)` for transparent per-component reporting.

**`pipeline/inference.py`**
- Added `_assess_extraction_quality()` — two-check quality gate run before
  ensemble scoring. Returns `Inconclusive` with a descriptive message if
  rare letter ratio exceeds 0.55 or raw reversal mean exceeds 0.65.
  Inverted rare-letter logic handles short real words correctly (KITE FAMILY
  passes; 250-char noise sequence is blocked).
- Added LSTM saturation gate — LSTM contributes 30% of NLP component only
  when output is in (0.03, 0.97); otherwise analytical score used alone.

**`README.md`**
- Added quality gate block to inference pipeline diagram
- Added "Why a quality gate" design decision section
- Added row to improvements table

### Test Cases Verified

| Case | Before | After |
|---|---|---|
| Non-dyslexic short (KITE FAMILY) | False positive | No Dyslexia, High |
| Dyslexic short (inverted k,e,f,y) | Correct | Dyslexia, High |
| Dyslexic long paragraph | Low confidence, diluted | Detected, Medium |
| Noisy background image | 76.5% false positive | Inconclusive |

### No model retraining required
All changes are inference-time only.